### PR TITLE
Enforce trailing commas in hashs, arrays and method arguments

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -95,6 +95,15 @@ Style/SymbolProc:
   Exclude:
     - app/serializers/**/*_serializer.rb
 
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
 Style/HashEachMethods:
   Enabled: true
 


### PR DESCRIPTION
There's been a couple discussions around why we don't enforce trailing commas and the consensus seems to be that we want to enforce them. Here's a slack thread: https://underdog-inc.slack.com/archives/C02CMTK7WCF/p1680276116490249