### PR TITLE
Change Layout/Argument-Alignment to default

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -48,7 +48,7 @@ Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
 Layout/ArgumentAlignment:
-  EnforcedStyle: with_fixed_indentation
+  EnforcedStyle: with_first_argument
 
 Layout/HashAlignment:
   EnforcedLastArgumentHashStyle: ignore_implicit


### PR DESCRIPTION
[Original Slack thread discussing this change](https://underdog-inc.slack.com/archives/C02CMTK7WCF/p1681497563099789):

RuboCop change proposal:
Layout/ArgumentAlignment:  with_fixed_indentation  =>  with_first_argument

[See here for this Cop's documentation](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/ArgumentAlignment)

--------  --------  --------  --------  --------
Reasons:
1. The change allows for the following extremely common pattern:
```ruby
    attr_reader :author,
                :target,
                :product,
                :type
```
More generally speaking, "DSL" functions, in which parens are not included, disallow dropping the first argument to the next line. In these cases, the Cop actually forces an uncommon, and harder to read, pattern:
```ruby
    attr_reader :author,
       :target,
       :product,
       :type
```

2. The Cop change has a minimal area of effect. Dropping arguments onto the next line is almost always used; thus, this change requires little to no code changes (none in the Warden repo). Likely there is almost no refactor necessary due to style conventions.
```ruby
# Common.
foo(
  :bar,
  :baz,
  key: value
)

# Almost never.
foo(:bar,
  :baz,
  key: value
)
```

3. RubyMine doesn't allow for auto-formatting with the current Cop setting (with_fixed_indentation). This makes working common Rails DSL methods annoying and painful for developers.

4. The proposed change is actually a return to the default setting for this Cop. I'm not sure the original reasoning behind stepping away from the default, but it seems like we should re-evaluate.