### PR TITLE
Bump rubocop version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,3 @@ gemspec
 gem "bundler", "~> 2.3"
 gem "minitest", "~> 5.0"
 gem "rake", "~> 13.0"
-gem "rubocop", "~> 1.21"

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in underdog_ruby_style.gemspec
 gemspec
 
-gem "rake", "~> 13.0"
-
+gem "bundler", "~> 2.3"
 gem "minitest", "~> 5.0"
-
+gem "rake", "~> 13.0"
 gem "rubocop", "~> 1.21"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     underdog_ruby_style (0.1.0)
-      rubocop (= 1.41.1)
+      rubocop (= 1.57.2)
       rubocop-minitest
       rubocop-performance
       rubocop-rails
@@ -20,27 +20,31 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
+    language_server-protocol (3.17.0.3)
     minitest (5.16.3)
-    parallel (1.22.1)
-    parser (3.1.3.0)
+    parallel (1.23.0)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rack (3.0.6.1)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.6.1)
-    rexml (3.2.5)
-    rubocop (1.41.1)
+    regexp_parser (2.8.2)
+    rexml (3.2.6)
+    rubocop (1.57.2)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.2.1)
+      parser (>= 3.2.2.4)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.23.0, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.24.0)
-      parser (>= 3.1.1.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
     rubocop-minitest (0.25.1)
       rubocop (>= 0.90, < 2.0)
     rubocop-performance (1.15.2)
@@ -50,13 +54,14 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
-    ruby-progressbar (1.11.0)
+    ruby-progressbar (1.13.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.3.0)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,6 @@ DEPENDENCIES
   bundler (~> 2.3)
   minitest (~> 5.0)
   rake (~> 13.0)
-  rubocop (~> 1.21)
   underdog_ruby_style!
 
 BUNDLED WITH

--- a/underdog_ruby_style.gemspec
+++ b/underdog_ruby_style.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
-  spec.add_dependency "rubocop", "1.41.1"
+  spec.add_dependency "rubocop", "1.57.2"
   spec.add_dependency "rubocop-minitest"
   spec.add_dependency "rubocop-performance"
   spec.add_dependency "rubocop-rails"

--- a/underdog_ruby_style.gemspec
+++ b/underdog_ruby_style.gemspec
@@ -36,7 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-minitest"
   spec.add_dependency "rubocop-performance"
   spec.add_dependency "rubocop-rails"
-  spec.add_development_dependency "bundler", "~> 2.3"
-  spec.add_development_dependency "rake", "~> 13.0"
   spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
Bumping the rubocop version up to the most recent: https://github.com/rubocop/rubocop/releases